### PR TITLE
update from density to pmf

### DIFF
--- a/reference/random/generated/numpy.random.binomial.html
+++ b/reference/random/generated/numpy.random.binomial.html
@@ -728,7 +728,7 @@ each sample is equal to the number of successes over the n trials.</p>
 </dl>
 </div>
 <p class="rubric">Notes</p>
-<p>The probability density for the binomial distribution is</p>
+<p>The probability mass function (PMF) for the binomial distribution is</p>
 <div class="math notranslate nohighlight">
 \[P(N) = \binom{n}{N}p^N(1-p)^{n-N},\]</div>
 <p>where <span class="math notranslate nohighlight">\(n\)</span> is the number of trials, <span class="math notranslate nohighlight">\(p\)</span> is the probability


### PR DESCRIPTION
This will fix the typo of 'density' to 'mass function (PMF)', in the formula of binomial distribution. 
As the binomial distribution has discrete random variables, its distribution is always a Probability Mass Function (PMF) and not Probability Density Function (PDF)